### PR TITLE
Fix cppcheck inconclusive flag invocation

### DIFF
--- a/codeclimate-cppcheck.py
+++ b/codeclimate-cppcheck.py
@@ -85,7 +85,7 @@ def get_config_and_filelist():
             arguments.append('--max-configs={}'.format(
                 config.get('max_configs')))
         if config.get('inconclusive', 'true') == 'true':
-            arguments.append('-inconclusive')
+            arguments.append('--inconclusive')
     return arguments, filelistpath
 
 


### PR DESCRIPTION
Should be `--inconclusive` vs `-inconclusive`.