### PR TITLE
Update issue classification for cppcheck `error` severity

### DIFF
--- a/lib/issue_formatter.py
+++ b/lib/issue_formatter.py
@@ -56,7 +56,7 @@ class IssueFormatter:
         # http://cppcheck.sourceforge.net/devinfo/doxyoutput/classSeverity.html
         # https://github.com/codeclimate/spec/blob/master/SPEC.md
         if severity == 'error':
-            return ('Security', 'critical')
+            return ('Performance', 'critical')
         if severity == 'warning':
             return ('Bug Risk', 'normal')
         if severity == 'style':


### PR DESCRIPTION
Update cppcheck `error` issues to be formatted with a category of `Performance` with `critical` severity.

Addresses https://github.com/antiagainst/codeclimate-cppcheck/issues/9