### PR TITLE
Update packaging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,21 @@
-FROM alpine:3.5
-MAINTAINER Lei Zhang <antiagainst@gmail.com>
+FROM alpine:3.8
+LABEL maintainer "Lei Zhang <antiagainst@gmail.com>"
 
-ADD repositories /etc/apk/repositories
+WORKDIR /usr/src/app
+COPY docker/files /
 
-RUN apk --update add --no-cache --upgrade cppcheck@community python3 py3-lxml@main
+RUN apk --update add --no-cache --upgrade \
+      cppcheck@community \
+      python3 \
+      py3-lxml@main && \
+    rm -rf /usr/share/ri && \
+    adduser -u 9000 -D -s /bin/false app
 
-RUN adduser -u 9000 -D -s /bin/false app
+COPY engine.json /
+COPY . ./
+RUN chown -R app:app ./
+
 USER app
-
-COPY . /usr/src/app
 
 VOLUME /code
 WORKDIR /code

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+.PHONY: image
+
+IMAGE_NAME ?= codeclimate/codeclimate-cppcheck
+
+image:
+	docker build --rm -t $(IMAGE_NAME) .

--- a/docker/files/etc/apk/repositories
+++ b/docker/files/etc/apk/repositories
@@ -1,4 +1,4 @@
-http://dl-4.alpinelinux.org/alpine/v3.5/main
-http://dl-4.alpinelinux.org/alpine/v3.5/community
+http://dl-4.alpinelinux.org/alpine/v3.8/main
+http://dl-4.alpinelinux.org/alpine/v3.8/community
 @main    http://dl-4.alpinelinux.org/alpine/edge/main
 @community http://dl-4.alpinelinux.org/alpine/edge/community


### PR DESCRIPTION
**Add Makefile**

Supports only `make image` target right now.

**Update docker packaging**

- Update base image to alpine:3.8
- Update maintainer label
- Run chown on copied engine files
- Move alpine repositories system file
- COPY engine.json to /