### PR TITLE
Add special case handling for 'force' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ in `.codeclimate.yml`:
   this is not needed.
   Refer to the `-I` option of `cppcheck` for more information.
 * `max_configs`: maximum number of configurations to check in a file before
-  skipping it. Default is '12'.
-  Refer to the `--max-configs=` option of `cppcheck` for more information.
+  skipping it. Default is 12. `max_configs` can also be set to `force`, which
+  forces `cppcheck` to check all configs.
+  Refer to the `--max-configs=` and `--force` options of `cppcheck` for more
+  information.
 * `inconclusive`: allow reporting issues that are not inconclusive.
   Refer to the `--inconclusive` option of `cppcheck` for more information.
 

--- a/lib/command.py
+++ b/lib/command.py
@@ -31,7 +31,10 @@ class Command:
             command.append('-I{}'.format(directory))
 
         if self.config.get('max_configs'):
-            command.append('--max-configs={}'.format(self.config.get('max_configs')))
+            if self.config.get('max_configs') == 'force':
+                command.append('--force')
+            else:
+                command.append('--max-configs={}'.format(self.config.get('max_configs')))
 
         if self.config.get('inconclusive', 'true') == 'true':
             command.append('--inconclusive')


### PR DESCRIPTION
Basically, as I wrote in the comment of the first commit in this PR, the idea is to add it as a special case of `max_configs` as then it should never be unclear as to what option actually prevails (as opposed to adding it as a separate setting in the config yml).