### PR TITLE
Changes default behavior of --enable option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ Like the `cppcheck` command line tool itself, you can configure various
 aspects of the static analysis. Right now, the following options are supported
 in `.codeclimate.yml`:
 
-* `check`: issue categories to check. Available values are: `all`, `warning`,
-  `style`, `performance`, `portability`, `information`, `unusedFunction`, etc.
+* `check`: issue categories to check. 
+  By default, no additional checks are enabled.
+  Available values are: `all`, `warning`, `style`, `performance`, `portability`,
+  `information`, `unusedFunction`, etc.
   Refer to the `--enable=` option of `cppcheck` for more information.
 * `project`: use Visual Studio project/solution (`*.vcxproj`/`*sln`) or compile
   database (`compile_commands.json`) for files to analyse, include paths,

--- a/lib/command.py
+++ b/lib/command.py
@@ -7,7 +7,8 @@ class Command:
     def build(self):
         command = ['cppcheck']
 
-        command.append('--enable={}'.format(self.config.get('check', 'all')))
+        if self.config.get('check'):
+            command.append('--enable={}'.format(self.config.get('check')))
 
         if self.config.get('project'):
             command.append('--project={}'.format(self.config.get('project')))


### PR DESCRIPTION
* Previously, if no value was given for the `check` configuration value,
`codeclimate-cppcheck` would default to `all`
* Changes the default behavior to only enable checks if they are provided
* Updates README to document this change