### PR TITLE
fix(docs): example config version value is a string.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Additional options may be supported later.
 An example `.codeclimate.yml` file:
 
 ```yaml
-version: 2
+version: "2"
 plugins:
   cppcheck:
     enabled: true


### PR DESCRIPTION
Per CodeClimate docs, the version value of the `.codeclimate.yml` config should be a string.

```yml
version: "2"
plugins:
  [plugin name]:
    enabled: true
```

> https://docs.codeclimate.com/docs/advanced-configuration