### PR TITLE
Add support for inline suppressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,11 @@ in `.codeclimate.yml`:
   information.
 * `inconclusive`: allow reporting issues that are not inconclusive.
   Refer to the `--inconclusive` option of `cppcheck` for more information.
-* `suppressions-list`: suppress warnings listed in the file..
+* `suppressions-list`: suppress warnings listed in the file.
   Refer to the `--suppressions-list` option of `cppcheck` for more information.
+* `inline-suppr`: allow suppression of warnings with inline comments, 
+  for example: `// cppcheck-suppress arrayIndexOutOfBounds`.
+  Refer to the `--inline-suppr` option of `cppcheck` for more information
 
 Additional options may be supported later.
 
@@ -84,6 +87,7 @@ plugins:
       max_configs: 42
       inconclusive: false
       suppressions-list: .cppcheck-suppressions
+      inline-suppr: true
 ```
 
 ## Need help?

--- a/lib/command.py
+++ b/lib/command.py
@@ -42,6 +42,9 @@ class Command:
             
         if self.config.get('suppressions-list'):
             command.append('--suppressions-list={}'.format(self.config.get('suppressions-list')))
+        
+        if self.config.get('inline-suppr', 'false') == 'true':
+            command.append('--inline-suppr')
 
         command.extend(['--xml', '--xml-version=2'])
         command.append('--file-list={}'.format(self.file_list_path))


### PR DESCRIPTION
Inline suppressions can be activated by providing the `--inline-suppr` flag.

Defaults to `false` in config

Example taken from [**Section 6.5** of the `cppcheck` manual](http://cppcheck.sourceforge.net/manual.pdf)

> ```bash
> void f() {
>     char arr[5];
>     // cppcheck-suppress arrayIndexOutOfBounds
>     arr[10] = 0;
> }
> ```
> Now the `--inline-suppr` flag can be used to suppress the warning. No error is
reported when invoking cppcheck this way:
> ```bash
> cppcheck --inline-suppr test.c
> ```