### PR TITLE
update alpine image to 3.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.14
 LABEL maintainer "Lei Zhang <antiagainst@gmail.com>"
 
 WORKDIR /usr/src/app


### PR DESCRIPTION
This bumps cppcheck to version 2.4.1, which has a good c++17 support
(https://sourceforge.net/p/cppcheck/news/2021/04/c17-support-in-cppcheck/)