### PR TITLE
Adds support for library option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ in `.codeclimate.yml`:
 * `platform`: specifies platform specific types and sizes. Available builtin
   platforms are: `unix32`, `unix64`, `win32A`, `win32W`, `win64`, etc.
   Refer to the `--platform=` option of `cppcheck` for more information.
+* `library`: specifies library `cfg` files to be loaded. Refer to the 
+  `--library=` option of `cppcheck` for more information.
 * `defines`: define preprocessor symbols.
   Refer to the `-D` option of `cppcheck` for more information.
 * `undefines`: undefine preprocessor symbols.

--- a/lib/command.py
+++ b/lib/command.py
@@ -21,6 +21,9 @@ class Command:
 
         if self.config.get('platform'):
             command.append('--platform={}'.format(self.config.get('platform')))
+            
+        if self.config.get('library'):
+            command.append('--library={}'.format(self.config.get('library')))
 
         for symbol in self.config.get('defines', []):
             command.append('-D{}'.format(symbol))


### PR DESCRIPTION
This is in order to be able to use `--library=googletest` but it could also be used to load any library cfg files from https://github.com/danmar/cppcheck/tree/main/cfg